### PR TITLE
DFR_Events Prep() compiler error fix

### DIFF
--- a/Source/Scripts/DFR_Events.psc
+++ b/Source/Scripts/DFR_Events.psc
@@ -183,3 +183,8 @@ endFunction
 string function IncreasesFavour(string asId)
     return StorageUtil.GetStringValue(self, "DFR_EventContext_" + asId, -1)
 endFunction
+
+;legacy fix - krzp
+function Prep(bool abForced = false, string asType)
+    Setup(Utility.CreateStringArray(1, asType), 0, abForced, abForced)
+endFunction


### PR DESCRIPTION
Quick and hacky, but should fix at least ~15 errors